### PR TITLE
Implement recursive DNS queries

### DIFF
--- a/cmd/who-dis/main.go
+++ b/cmd/who-dis/main.go
@@ -14,7 +14,7 @@ func main() {
 	}
 	dn := os.Args[1]
 	client := dns.NewDNSClient()
-	err := client.Query(dn)
+	err := client.Query(dn, true)
 	if err != nil {
 		fmt.Println(err)
 	}


### PR DESCRIPTION
Mimics the behaviour of `dig +trace`. Note that we need some caching in place otherwise all root servers and TLD servers will slowly hate us.